### PR TITLE
Fix plugin install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@
 Install the plugin:
 
 ```bash
-cd /var/lib/dokku/plugins
-git clone https://github.com/256dpi/dokku-haproxy.git
-dokku plugins-install
+dokku plugin:install https://github.com/256dpi/dokku-haproxy.git
 ```
 
 ## Configuration


### PR DESCRIPTION
Install instructions didn't work for me. I updated them with a simple command to run.

I also think the command example should change. "process-name" really means Container Type (E.G. web) and other commands should probably be written there but that isn't part of this PR.
