### PR TITLE
Compatibility upgrade

### DIFF
--- a/create-config
+++ b/create-config
@@ -27,7 +27,8 @@ if(fs.existsSync(ports_file)) {
   });
 
   var config = mappings.map(function(m){
-    var s = 'listen port-' + m[0] + ' :' + m[0] + '\n';
+    var s = 'listen port-' + m[0] + '\n';
+    s += '  bind *:' + m[0] + '\n';
     s += '  mode tcp\n';
     s += '  log global\n';
     s += '  option tcplog\n',

--- a/install
+++ b/install
@@ -27,7 +27,7 @@ global
 EOF
 
 # set new haproxy config location
-sudo sed -i 's/CONFIG=\/etc\/haproxy\/haproxy.cfg/CONFIG=\/var\/lib\/dokku-haproxy\/haproxy.cfg/g' /etc/init.d/haproxy
+sudo sed -i 's/#CONFIG=\/etc\/haproxy\/haproxy.cfg/CONFIG=\/var\/lib\/dokku-haproxy\/haproxy.cfg/g' /etc/default/haproxy
 
 # enable stats
 cat<<EOF > /var/lib/dokku-haproxy/_11_stats.cfg

--- a/install
+++ b/install
@@ -27,11 +27,12 @@ global
 EOF
 
 # set new haproxy config location
-sudo sed -i 's/#CONFIG=\/etc\/haproxy\/haproxy.cfg/CONFIG=\/var\/lib\/dokku-haproxy\/haproxy.cfg/g' /etc/default/haproxy
+sudo sed -i 's/#CONFIG=\"\/etc\/haproxy\/haproxy.cfg\"/CONFIG=\"\/var\/lib\/dokku-haproxy\/haproxy.cfg\"/g' /etc/default/haproxy
 
 # enable stats
 cat<<EOF > /var/lib/dokku-haproxy/_11_stats.cfg
-listen stats :9090
+listen stats
+  bind :9000
   mode http
   timeout connect 5s
   timeout client 24h

--- a/plugin.toml
+++ b/plugin.toml
@@ -1,4 +1,4 @@
 [plugin]
 description = "haproxy tcp load balancer for dokku"
-version = "0.1.0"
+version = "0.1.1"
 [plugin.config]


### PR DESCRIPTION
2 years later, things have changed:
* haproxy config syntax: giving a port to `listen` is deprecated; use `bind` instead
* systemd: haproxy now comes with a systemd service configuration, which uses `/etc/default/haproxy` to control which config file to use